### PR TITLE
changed README to account for pythonpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A Python SDK for interactions with [Cobo Safe](https://github.com/coboglobal/cob
 # Installation
 
 ```sh
+cd pycobosafe
+export PYTHONPATH=.
 pip install git+https://github.com/coboglobal/pycobosafe
 ```
 


### PR DESCRIPTION
Without setting PYTHONPATH, the program is unable to load the ABIs from pycobosafe/abi to create BaseOwnable objects, resulting in the [authorizer].abi file not found error.