### PR TITLE
writing export function to yaml file

### DIFF
--- a/pycobosafe/abi/StargateWithdrawAuthorizer.json
+++ b/pycobosafe/abi/StargateWithdrawAuthorizer.json
@@ -1,0 +1,968 @@
+[
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_owner",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "_caller",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "AccountSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "_poolAddress",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "user",
+            "type": "address"
+          }
+        ],
+        "name": "AddPoolAddressWhitelist",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "_poolId",
+            "type": "uint256"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "user",
+            "type": "address"
+          }
+        ],
+        "name": "AddPoolIdWhitelist",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "caller",
+            "type": "address"
+          }
+        ],
+        "name": "CallerSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          }
+        ],
+        "name": "NewOwnerSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "bool",
+            "name": "status",
+            "type": "bool"
+          }
+        ],
+        "name": "PausedSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          }
+        ],
+        "name": "PendingOwnerSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "_poolAddress",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "user",
+            "type": "address"
+          }
+        ],
+        "name": "RemovePoolAddressWhitelist",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "_poolId",
+            "type": "uint256"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "user",
+            "type": "address"
+          }
+        ],
+        "name": "RemovePoolIdWhitelist",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "bytes32",
+            "name": "tag",
+            "type": "bytes32"
+          }
+        ],
+        "name": "TagSet",
+        "type": "event"
+      },
+      {
+        "stateMutability": "nonpayable",
+        "type": "fallback"
+      },
+      {
+        "inputs": [],
+        "name": "NAME",
+        "outputs": [
+          {
+            "internalType": "bytes32",
+            "name": "",
+            "type": "bytes32"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "TYPE",
+        "outputs": [
+          {
+            "internalType": "bytes32",
+            "name": "",
+            "type": "bytes32"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "VERSION",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "_NAME",
+        "outputs": [
+          {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "acceptOwner",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "account",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address[]",
+            "name": "_poolAddresses",
+            "type": "address[]"
+          }
+        ],
+        "name": "addPoolAddresses",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "uint256[]",
+            "name": "_poolIds",
+            "type": "uint256[]"
+          }
+        ],
+        "name": "addPoolIds",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "caller",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "contracts",
+        "outputs": [
+          {
+            "internalType": "address[]",
+            "name": "_contracts",
+            "type": "address[]"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "flag",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "getPoolAddressWhiteList",
+        "outputs": [
+          {
+            "internalType": "address[]",
+            "name": "",
+            "type": "address[]"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "getPoolIdWhiteList",
+        "outputs": [
+          {
+            "internalType": "uint256[]",
+            "name": "",
+            "type": "uint256[]"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_owner",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "_caller",
+            "type": "address"
+          }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_owner",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "_caller",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "_account",
+            "type": "address"
+          }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_owner",
+            "type": "address"
+          }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "uint16",
+            "name": "_srcPoolId",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "_to",
+            "type": "address"
+          }
+        ],
+        "name": "instantRedeemLocal",
+        "outputs": [],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "paused",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "pendingOwner",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "delegate",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "flag",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "hint",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "extra",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct TransactionData",
+            "name": "transaction",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "bool",
+                "name": "success",
+                "type": "bool"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "hint",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct TransactionResult",
+            "name": "callResult",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum AuthResult",
+                "name": "result",
+                "type": "uint8"
+              },
+              {
+                "internalType": "string",
+                "name": "message",
+                "type": "string"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct AuthorizerReturnData",
+            "name": "preData",
+            "type": "tuple"
+          }
+        ],
+        "name": "postExecCheck",
+        "outputs": [
+          {
+            "components": [
+              {
+                "internalType": "enum AuthResult",
+                "name": "result",
+                "type": "uint8"
+              },
+              {
+                "internalType": "string",
+                "name": "message",
+                "type": "string"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct AuthorizerReturnData",
+            "name": "authData",
+            "type": "tuple"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "delegate",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "flag",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "hint",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "extra",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct TransactionData",
+            "name": "transaction",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "bool",
+                "name": "success",
+                "type": "bool"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "hint",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct TransactionResult",
+            "name": "callResult",
+            "type": "tuple"
+          }
+        ],
+        "name": "postExecProcess",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "delegate",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "flag",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "hint",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "extra",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct TransactionData",
+            "name": "transaction",
+            "type": "tuple"
+          }
+        ],
+        "name": "preExecCheck",
+        "outputs": [
+          {
+            "components": [
+              {
+                "internalType": "enum AuthResult",
+                "name": "result",
+                "type": "uint8"
+              },
+              {
+                "internalType": "string",
+                "name": "message",
+                "type": "string"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct AuthorizerReturnData",
+            "name": "authData",
+            "type": "tuple"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "delegate",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "flag",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "hint",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "extra",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct TransactionData",
+            "name": "transaction",
+            "type": "tuple"
+          }
+        ],
+        "name": "preExecProcess",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address[]",
+            "name": "_poolAddresses",
+            "type": "address[]"
+          }
+        ],
+        "name": "removePoolAddresses",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "uint256[]",
+            "name": "_poolIds",
+            "type": "uint256[]"
+          }
+        ],
+        "name": "removePoolIds",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "router",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_account",
+            "type": "address"
+          }
+        ],
+        "name": "setAccount",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_caller",
+            "type": "address"
+          }
+        ],
+        "name": "setCaller",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "bool",
+            "name": "_paused",
+            "type": "bool"
+          }
+        ],
+        "name": "setPaused",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          }
+        ],
+        "name": "setPendingOwner",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "bytes32",
+            "name": "_tag",
+            "type": "bytes32"
+          }
+        ],
+        "name": "setTag",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "stakingPool",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "stargateFactory",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "tag",
+        "outputs": [
+          {
+            "internalType": "bytes32",
+            "name": "",
+            "type": "bytes32"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "newOwner",
+            "type": "address"
+          }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "uint256",
+            "name": "_pid",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "name": "withdraw",
+        "outputs": [],
+        "stateMutability": "view",
+        "type": "function"
+      }
+    ]

--- a/pycobosafe/autocontract.py
+++ b/pycobosafe/autocontract.py
@@ -40,3 +40,10 @@ def dump(addr, full=False):
         obj.dump(full)
     else:
         print("No valid IVersion contract.")
+
+def export_config(addr):
+    obj = convert(addr)
+    if obj:
+        obj.export_config(obj.name)
+    else:
+        print("No valid IVersion contract.")

--- a/pycobosafe/console.py
+++ b/pycobosafe/console.py
@@ -267,6 +267,14 @@ class CoboSafeConsole(cmd.Cmd):
         from .autocontract import dump
 
         dump(addr, len(args) > 1)
+    
+    def do_export_config(self, arg):
+        args = arg.split()
+        addr = self._arg_as_addr(args[0])
+
+        from .autocontract import export_config
+
+        export_config(addr)
 
     # Cobo safe interaction commands
 

--- a/pycobosafe/ownable.py
+++ b/pycobosafe/ownable.py
@@ -1,5 +1,5 @@
 from brownie import network
-
+import yaml
 from .utils import ZERO_ADDRESS, load_contract, s32
 
 
@@ -48,6 +48,19 @@ class BaseOwnable(object):
                 print("Pending owner:", pending)
         except Exception:
             pass
+    
+    def export_config(self, filename=None):
+        if filename == None:
+            filename = self.contract.name
+        f = open(f'pycobosafe/{filename}_export_config.yaml','w')
+        try:
+            owner = self.owner
+            pending = self.pending_owner
+            if pending != ZERO_ADDRESS:
+                owner = pending
+        except Exception:
+            pass
+        yaml.dump({"Name":self.name, "Address":self.address, "Version":self.version, "Owner":owner}, f)
 
 
 class ERC20(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ eth_utils==1.10.0
 pytest==6.2.5
 python-dotenv==0.16.0
 web3==5.31.1
+PyYAML==5.4.1


### PR DESCRIPTION
加 export 函数把 authorizer 本来 dump 出来的信息放到 yaml 文件里

StargateWithdrawAuthorizer 输出的信息, 在StargateWithdrawAuthorizer_export_config.yaml里面:
> Address: '0x81e62Ae20533385d07Fb752f840930BdE2641433'
> Name: StargateWithdrawAuthorizer
> Owner: !!python/object/new:brownie.convert.datatypes.EthAddress
> \- '0xaA162488147FE4aC566edD2bE5453e98b8843425'
> Version: !!python/object/new:brownie.convert.datatypes.Wei
> \- 1
> Caller: !!python/object/new:brownie.convert.datatypes.EthAddress
> \- '0xEc4e47299515aB82dAa1c9d34C0C02486064F5CD'
> Flags: PreCheck
> Tag: ArgusStgETHV1-Withdraw
> Type: CommonType
> Contracts:
> \- !!python/object/new:brownie.convert.datatypes.EthAddress
>   \- '0x8731d54E9D02c286767d56ac03e8037C07e01e98'
> \- !!python/object/new:brownie.convert.datatypes.EthAddress
>   \- '0xB0D502E938ed5f4df2E681fE6E419ff29631d62b'
> Whitelist IDs:
> \- !!python/object/new:brownie.convert.datatypes.Wei
>   \- 2
> Whitelist addresses:
> \- !!python/object/new:brownie.convert.datatypes.EthAddress
>   \- '0x101816545F6bd2b1076434B54383a1E633390A2E'
